### PR TITLE
oauth2 has moved to github

### DIFF
--- a/README
+++ b/README
@@ -34,6 +34,7 @@ mkdir -p $GOPATH/{src,pkg,bin}
 
 go get github.com/fluffle/goirc/client
 go get github.com/kuroneko/gosqlite3
+go get github.com/golang/oauth2
 go get gopkg.in/mgo.v2
 
 4) Clone sp0rkle's code from github.

--- a/drivers/netdriver/github.go
+++ b/drivers/netdriver/github.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"code.google.com/p/goauth2/oauth"
+	"github.com/golang/oauth2"
 	"github.com/fluffle/golog/logging"
 	"github.com/fluffle/sp0rkle/bot"
 	"github.com/fluffle/sp0rkle/collections/reminders"
@@ -26,8 +26,12 @@ const (
 )
 
 func githubClient() *github.Client {
-	t := &oauth.Transport{Token: &oauth.Token{AccessToken: bot.GetSecret(*githubToken)}}
-	return github.NewClient(t.Client())
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: bot.GetSecret(*githubToken)},
+	)
+	tc := oauth2.NewClient(oauth2.NoContext, ts)
+
+	return github.NewClient(tc)
 }
 
 func githubCreateIssue(ctx *bot.Context) {


### PR DESCRIPTION
Testing
If I pass my token I get at the command line

[20:16] < sl__p> sloop: Error creating issue: POST https://api.github.com/repos/fluffle/sp0rkle/issues: 404 Not Found []

If I pass an invalid token
[20:17] < sl__p> sloop: Error creating issue: POST https://api.github.com/repos/bob-smith/sp0rkle/issues: 401 Bad credentials []

So that makes me think it's now working, though you will want to test with a valid token for that project