### PR TITLE
Update link to mongodb on Linux

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,7 @@ mongod --version
 db version v2.2.1, pdfile version 4.5
 
 If not the following page may help
-http://www.mongodb.org/display/DOCS/Ubuntu+and+Debian+packages
+https://docs.mongodb.org/manual/administration/install-on-linux/
 
 2) Build go.
 


### PR DESCRIPTION
docs.mongodb.org has had a reorg.
Link to the Linux section, there are separate pages under that for Debian and Ubuntu