### PR TITLE
Working Travis Builds for sp0rkle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+---
+language: go
+
+go:
+  - 1.3
+
+sudo : false
+
+install:
+  - go get github.com/fluffle/goirc/client
+  - go get github.com/kuroneko/gosqlite3
+  - go get github.com/golang/oauth2
+  - go get gopkg.in/mgo.v2
+
+
+    #sudo apt-get install build-essential bison mongodb libsqlite3-dev
+    #sudo apt-get install mercurial git bzr
+
+script: go build
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,8 @@ install:
     #sudo apt-get install build-essential bison mongodb libsqlite3-dev
     #sudo apt-get install mercurial git bzr
 
-script: go build
+script:
+  - find /home/travis/.gimme/versions/go1.3.linux.amd64/src/pkg/github.com
+  - find /home/travis/gopath/src/github.com/fluffle
+  - go build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,12 @@ install:
     #sudo apt-get install mercurial git bzr
 
 script:
-  - find /home/travis/.gimme/versions/go1.3.linux.amd64/src/pkg/github.com
+# HORRIBLE HACK
+#    main.go:10:2: cannot find package "github.com/fluffle/sp0rkle/bot" in any of:
+#    Work around by symlinking in
+#    FIXME: This is only needed on !fluffle, maybe detect repo, or just ignore this once it's in upstream?
+  - ln -s $HOME/gopath/src/github.com/bob-smith/sp0rkle /home/travis/gopath/src/github.com/fluffle/sp0rkle
+    ls -la /home/travis/gopath/src/github.com/fluffle/
   - find /home/travis/gopath/src/github.com/fluffle
   - go build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
 #    Work around by symlinking in
 #    FIXME: This is only needed on !fluffle, maybe detect repo, or just ignore this once it's in upstream?
   - ln -s $HOME/gopath/src/github.com/bob-smith/sp0rkle /home/travis/gopath/src/github.com/fluffle/sp0rkle
-    ls -la /home/travis/gopath/src/github.com/fluffle/
+  - ls -la /home/travis/gopath/src/github.com/fluffle/
   - find /home/travis/gopath/src/github.com/fluffle
   - go build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ go:
 
 sudo : false
 
+# NOTE: Any extra dependencies added here must be reflected in README.md
 install:
   - go get github.com/fluffle/goirc/client
+  - go get github.com/fluffle/golog/logging
   - go get github.com/kuroneko/gosqlite3
   - go get github.com/golang/oauth2
   - go get gopkg.in/mgo.v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - go get github.com/golang/oauth2
   - go get gopkg.in/mgo.v2
 
-
+    # Not testing with DB, just that it builds
     #sudo apt-get install build-essential bison mongodb libsqlite3-dev
     #sudo apt-get install mercurial git bzr
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - go get github.com/fluffle/goirc/client
   - go get github.com/fluffle/golog/logging
   - go get github.com/kuroneko/gosqlite3
+  - go get github.com/google/go-github/github
   - go get github.com/golang/oauth2
   - go get gopkg.in/mgo.v2
 


### PR DESCRIPTION
Add basic but functional travis-ci builds.
Installs needed dependencies from upstream
  This will protect us against API changes
  Help us keep dependencies in README.md in sync

**Not implemented**

- Not currently running tests. Just checking code builds
- Not doing anything with factiods or quotes - I'd hope tests fail as dependencies are not present


**To enable**

- Link github to https://travis-ci.org/fluffle
- Enable travis for Sp0rkle - defaults are OK
- Make a change to any file to trigger a build
- Remove the horrible hacks once this is upstream
