### PR TITLE
Date format has changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ go:
 
 sudo : false
 
+notifications:
+      irc: "irc.pl0rt.org#sp0rklf"
+
 # NOTE: Any extra dependencies added here must be reflected in README.md
 install:
   - go get github.com/fluffle/goirc/client
@@ -28,12 +31,10 @@ install:
     #sudo apt-get install mercurial git bzr
 
 script:
-# HORRIBLE HACK
 #    main.go:10:2: cannot find package "github.com/fluffle/sp0rkle/bot" in any of:
 #    Work around by symlinking in
-#    FIXME: This is only needed on !fluffle, maybe detect repo, or just ignore this once it's in upstream?
-  - ln -s $HOME/gopath/src/github.com/bob-smith/sp0rkle /home/travis/gopath/src/github.com/fluffle/sp0rkle
+  - if [ "$TRAVIS_REPO_SLUG" != "fluffle/sp0rkle" ] ; then ln -s "$HOME/gopath/src/github.com/$TRAVIS_REPO_SLUG" /home/travis/gopath/src/github.com/fluffle/sp0rkle ; fi
   - ls -la /home/travis/gopath/src/github.com/fluffle/
   - find /home/travis/gopath/src/github.com/fluffle
-  - go build
+  - go test -v ./...
 

--- a/drivers/factdriver/plugin_test.go
+++ b/drivers/factdriver/plugin_test.go
@@ -1,6 +1,7 @@
 package factdriver
 
 import (
+	"flag"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ func TestIdentifiers(t *testing.T) {
 		"$nick $chan $username $user $host $time $date",
 	}
 	// Static timestamp for great testing justice, no "local" time here kthx.
+	flag.Set("timezone", "UTC")
 	ts := time.Unix(1234567890, 0).UTC()
 	ctx := &bot.Context{
 		Line: &client.Line{
@@ -31,7 +33,7 @@ func TestIdentifiers(t *testing.T) {
 		"nothing to see here",
 		"just a tester",
 		"lots of tester tester tester",
-		"tester #test tests tests goirc.github.com 23:31:30 Fri Feb 13 23:31:30 2009",
+		"tester #test tests tests goirc.github.com 23:31:30 23:31:30, Friday 13 February 2009 UTC",
 	}
 	for i, s := range tests {
 		ret := id_replacer(s, ctx, ts)

--- a/util/datetime/datetime_test.go
+++ b/util/datetime/datetime_test.go
@@ -1,6 +1,7 @@
 package datetime
 
 import (
+	"flag"
 	"testing"
 	"time"
 )
@@ -24,8 +25,9 @@ func (tt timeTests) run(t *testing.T, start time.Time) {
 }
 
 func TestParseTimeFormats(t *testing.T) {
+	flag.Set("timezone", "UTC")
 	// RFC822 doesn't specify seconds, and Stamp doesn't specify year
-	ref := time.Date(2004, 6, 22, 13, 10, 0, 0, time.Local)
+	ref := time.Date(2004, 6, 22, 13, 10, 0, 0, time.UTC)
 	formats := []string{
 		time.ANSIC,
 		time.UnixDate,


### PR DESCRIPTION
9623531d840d7635f9925030fef0c96fc9e8734b changed the format of the
timestrings.
This change should make the unit tests pass on local machines (but not
Travis)

The following now passes on UK systems:

    time go test -v  ./...

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/fluffle/sp0rkle/65)
<!-- Reviewable:end -->
