### PR TITLE
Don't repeat default values for command line help

### DIFF
--- a/bot/handlers.go
+++ b/bot/handlers.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	channels *string = flag.String("channels", "#sp0rklf",
-		"Comma-separated list of channels to join, defaults to '#sp0rklf'")
+		"Comma-separated list of channels to join.")
 	rebuilder *string = flag.String("rebuilder", "",
 		"Nick[:password] to accept rebuild command from.")
 	oper *string = flag.String("oper", "",

--- a/db/connection.go
+++ b/db/connection.go
@@ -14,7 +14,7 @@ import (
 const DATABASE string = "sp0rkle"
 
 var database *string = flag.String("database", "localhost",
-	"Address of MongoDB server to connect to, defaults to localhost.")
+	"Address of MongoDB server to connect to.")
 
 var lock sync.Mutex
 var sessions []*mgo.Session


### PR DESCRIPTION
```
./sp0rkle --help 2> before
# make fixes
./sp0rkle --help 2> after
diff before after
3c3
<     	Comma-separated list of channels to join, defaults to '#sp0rklf' (default "#sp0rklf")
---
>     	Comma-separated list of channels to join. (default "#sp0rklf")
5c5
<     	Address of MongoDB server to connect to, defaults to localhost. (default "localhost")
---
>     	Address of MongoDB server to connect to. (default "localhost")
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/fluffle/sp0rkle/66)
<!-- Reviewable:end -->
