### PR TITLE
Only test on golang 1.5+. No need to irc join/part

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,6 @@
 language: go
 
 go:
-  - 1.3
-  - 1.3.3
-  - 1.4
-  - 1.4.1
-  - 1.4.2
-  - 1.4.3
   - 1.5
   - 1.5.3
   - 1.6
@@ -15,7 +9,10 @@ go:
 sudo : false
 
 notifications:
-      irc: "irc.pl0rt.org#sp0rklf"
+  irc:
+    channels:
+      - "irc.pl0rt.org#sp0rklf"
+    skip_join: true
 
 # NOTE: Any extra dependencies added here must be reflected in README.md
 install:


### PR DESCRIPTION
As previously discussed with fluffle we don't care about golang < 1.5
IRC bot doesn't need to join to post messages, so reduce join/part spam

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/fluffle/sp0rkle/68)
<!-- Reviewable:end -->
